### PR TITLE
Swaped dependency on node package bignum with pure javascript impleme…

### DIFF
--- a/geometry/utils.js
+++ b/geometry/utils.js
@@ -1,8 +1,8 @@
 'use strict'
-const bignum = require('bignum');
+const bignum = require('bn').BigInteger;
 const Long = require('long');
 
-const lowMask = bignum('ffffffff', 16);
+const lowMask = new bignum('ffffffff', 16);
 
 class Utils {
 	
@@ -35,7 +35,7 @@ class Utils {
 	}
 
 	long_from_bignum(bignum, signed) {
-		return new Long(bignum.and(lowMask).toNumber(), bignum.shiftRight(32).and(lowMask).toNumber(), signed ? false : true);
+		return new Long(bignum.and(lowMask).intValue(), bignum.shiftRight(32).and(lowMask).intValue(), signed ? false : true);
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/billyriantono/simple-s2-node#readme",
   "dependencies": {
-    "bignum": "^0.12.5",
+    "bn": "^1.0.1",
     "long": "^3.1.0"
   }
 }


### PR DESCRIPTION
Swaped dependency on node package bignum with pure javascript implementation in npm package 'bn' ( https://github.com/keybase/bn )

if you install `bignum` it is automatically used instead of pure javascript implementation. Simple S2 currently doesn't work with the native installation, because .or() function is not implemented in `bignum` wrapper,
